### PR TITLE
Fix hiding feedback blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,8 @@ function setBehaviour (overlay, surveyData, surveyId, appInfo) {
 				return false;
 			}
 
-			block.classList.add('n-feedback__survey-block--hidden');
-			nextBlock.classList.remove('n-feedback__survey-block--hidden');
+			block.classList.add('n-feedback--hidden');
+			nextBlock.classList.remove('n-feedback--hidden');
 		}, true);
 	});
 
@@ -75,7 +75,7 @@ function toggleOverlay (overlay){
 }
 
 function hideFeedbackButton (){
-	document.querySelector('.n-feedback__container').classList.add('n-feedback__container--hidden');
+	document.querySelector('.n-feedback__container').classList.add('n-feedback--hidden');
 }
 
 function populateContainer (container) {
@@ -106,8 +106,8 @@ module.exports.init = (appInfo) => {
 		try {
 			html = surveyBuilder.buildSurvey(surveyData, surveyId);
 		}catch( err ){
-			container.classList.add('hidden');
-			trigger.classList.add('hidden');
+			container.classList.add('n-feedback--hidden');
+			trigger.classList.add('n-feedback--hidden');
 			return false;
 		};
 

--- a/index.js
+++ b/index.js
@@ -32,8 +32,8 @@ function setBehaviour (overlay, surveyData, surveyId, appInfo) {
 				return false;
 			}
 
-			block.classList.add('hidden');
-			nextBlock.classList.remove('hidden');
+			block.classList.add('n-feedback__survey-block--hidden');
+			nextBlock.classList.remove('n-feedback__survey-block--hidden');
 		}, true);
 	});
 
@@ -75,7 +75,7 @@ function toggleOverlay (overlay){
 }
 
 function hideFeedbackButton (){
-	document.querySelector('.n-feedback__container').classList.add('hidden');
+	document.querySelector('.n-feedback__container').classList.add('n-feedback__container--hidden');
 }
 
 function populateContainer (container) {

--- a/main.scss
+++ b/main.scss
@@ -179,8 +179,7 @@
 	}
 }
 
-.n-feedback__container--hidden,
-.n-feedback__survey-block--hidden {
+.n-feedback--hidden {
 	display: none;
 }
 

--- a/main.scss
+++ b/main.scss
@@ -179,6 +179,11 @@
 	}
 }
 
+.n-feedback__container--hidden,
+.n-feedback__survey-block--hidden {
+	display: none;
+}
+
 // Hide on ad overlap
 @media (min-width: 980px) and (max-width: 1000px)  {
 	.n-feedback__container {

--- a/src/survey-builder.js
+++ b/src/survey-builder.js
@@ -96,7 +96,7 @@ function buildSurvey (surveyData, surveyId) {
 
 	surveyData.forEach( (block, blockId) => {
 		// Only show the first block initially, hide the others
-		const hiddenClass = (blockId === 0 ? '': 'n-feedback__survey-block--hidden');
+		const hiddenClass = (blockId === 0 ? '': 'n-feedback--hidden');
 		const blockHTML = [`<div class="n-feedback__survey-block ${hiddenClass} n-feedback__survey-block-${blockId}">`];
 
 		block.questions.forEach( question => {

--- a/src/survey-builder.js
+++ b/src/survey-builder.js
@@ -96,7 +96,7 @@ function buildSurvey (surveyData, surveyId) {
 
 	surveyData.forEach( (block, blockId) => {
 		// Only show the first block initially, hide the others
-		const hiddenClass = (blockId === 0 ? '': 'hidden');
+		const hiddenClass = (blockId === 0 ? '': 'n-feedback__survey-block--hidden');
 		const blockHTML = [`<div class="n-feedback__survey-block ${hiddenClass} n-feedback__survey-block-${blockId}">`];
 
 		block.questions.forEach( question => {


### PR DESCRIPTION
This fixes an issue where on pages that didn't have a `hidden` class in their CSS, the different blocks that make up a survey were all visible when the feedback component was open, making it look like this:

![image](https://user-images.githubusercontent.com/6975428/41775061-30588b44-761a-11e8-8166-6157803220c3.png)

 🐿 v2.9.0