### PR TITLE
Use change event as it is better supported

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function setBehaviour (overlay, surveyData, surveyId, appInfo) {
 	});
 
 	// Set up validation
-	context.addEventListener('input', event => {
+	context.addEventListener('change', event => {
 		const block = event.target.closest('.n-feedback__survey-block');
 		runValidation(block);
 	});


### PR DESCRIPTION
This was preventing the Next button from being enabled in iOS Safari.
 🐿 v2.9.0