### PR TITLE
Add an Accept header to JSON fetches to make it explicit we're fetchi…

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,11 @@ async function getSurveyData ( surveyId ){
 	// const surveyDataURL = 'http://local.ft.com:5005/public/survey.json';
 	// const surveyDataURL = `http://local.ft.com:3002/v1/survey/${surveyId}`;
 	const surveyDataURL = `https://www.ft.com/__feedback-api/v1/survey/${surveyId}`;
-	return fetch(surveyDataURL).then( res => {
+	return fetch(surveyDataURL, {
+		headers: {
+			'Accept': 'application/json',
+		}
+	}).then( res => {
 		return res.json();
 	}).catch( () => {
 		// console.error('getSurveyData: XHR: ', err);

--- a/src/post-response.js
+++ b/src/post-response.js
@@ -33,6 +33,7 @@ function postResponse (surveyId, surveyData, surveyResponse, additionalData) {
 		credentials: 'include',
 		method: 'POST',
 		headers: {
+			'Accept': 'application/json',
 			'Content-Type': 'application/json'
 		},
 		body: JSON.stringify(body)


### PR DESCRIPTION
…ng JSON, to prevent Chrome from preventing requests on non-www.ft.com domains thanks to new CORB protections in Chrome 68+ (https://www.chromium.org/Home/chromium-security/corb-for-developers)