### PR TITLE
Hide the feedback container by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,6 +142,7 @@ module.exports.init = (appInfo) => {
 
 	getSurveyData(surveyId).then( surveyData => {
 		const container = document.querySelector('.n-feedback__container');
+		container.classList.remove('n-feedback--hidden');
 		populateContainer(container);
 		const trigger = document.querySelector('.n-feedback__container .n-feedback__survey-trigger');
 

--- a/templates/feedback-container.html
+++ b/templates/feedback-container.html
@@ -1,3 +1,3 @@
 {{#if @root.flags.qualtrics }}
-	<div class="n-feedback__container"></div>
+	<div class="n-feedback__container n-feedback--hidden"></div>
 {{/if}}


### PR DESCRIPTION
**Description**
On the signup forms that the feedback container leaves a unsightly empty white box on small screen sizes. This PR attempts to fix that by hiding the container by default and removing the class on initialisation.

| Before | After |
| --- | --- |
| <img width="494" alt="screen shot 2018-10-11 at 17 05 23" src="https://user-images.githubusercontent.com/1721150/46817983-05b02680-cd78-11e8-980d-7a90adc27012.png"> | <img width="410" alt="screen shot 2018-10-11 at 17 10 47" src="https://user-images.githubusercontent.com/1721150/46818252-a868a500-cd78-11e8-893d-b12393deeec4.png"> |


