### PR TITLE
Fault tolerancy to network

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ module.exports.init = (appInfo = {}) => {
 							}
 
 							feedbackOverlay.content.innerHTML = html;
-							setBehaviour(feedbackOverlay, surveyData, surveyId, appInfo);
+							setBehaviour(feedbackOverlay, surveyData, surveyId, appInfo, storeAndRetryInstance);
 
 							// run Validation as soon as you display the first block
 							const firstBlock = document.querySelectorAll('.n-feedback__survey-block', feedbackOverlay.content)[0];

--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ module.exports.init = (appInfo = {}) => {
 	// instances of n-feedback (for instance like the mobile App).
 	const storeAndRetryInstance = storeAndRetry.init();
 	// Attempt to resend existing (not posted already) responses.
-	storeAndRetry.attemptToPostPrestoredResponses();
+	storeAndRetryInstance.attemptToPostPrestoredResponses();
 
 	if (trigger) {
 		trigger.addEventListener('click', () => {

--- a/index.js
+++ b/index.js
@@ -54,8 +54,8 @@ function setBehaviour (overlay, surveyData, surveyId, appInfo, storeAndRetryInst
 			storeAndRetryInstance.postResponseWithRetry(surveyId, surveyData, surveyResponse, additionalData);
 			// TODO: Give user confirmation of success of failure
 			// https://github.com/Financial-Times/next-feedback-api/issues/47
-			// overlay.close();
-			// hideFeedbackButton(containerSelector);
+			overlay.close();
+			hideFeedbackButton(containerSelector);
 
 		});
 	}

--- a/index.js
+++ b/index.js
@@ -166,6 +166,8 @@ module.exports.init = (appInfo = {}) => {
 	// storeAndRetry is a singleton shared across multiple possible
 	// instances of n-feedback (for instance like the mobile App).
 	const storeAndRetryInstance = storeAndRetry.init();
+	// Attempt to resend existing (not posted already) responses.
+	storeAndRetry.attemptToPostPrestoredResponses();
 
 	if (trigger) {
 		trigger.addEventListener('click', () => {

--- a/src/lib/store-and-retry.js
+++ b/src/lib/store-and-retry.js
@@ -3,7 +3,7 @@
  * The module attempt to send a response of the survey and in case of failure will retry.
  * Once loaded, the module will check if a pre-existent response was stored without been send, if it found the response it will try to send it again.
  **/
-let _defaultPostResponse = require("../post-response");
+let _defaultPostResponse = require('../post-response');
 let _postResponse = null;
 // Number of retries before abandon.
 let defaultMaxRetries = 10;
@@ -16,155 +16,155 @@ let storage = null;
 let isStorageWritable = null;
 let isStorageReadable = null;
 // Name for the key in the web storage.
-const storageUniqueIdentifier = "n-feedback-response";
+const storageUniqueIdentifier = 'n-feedback-response';
 let attempts = null;
 let scheduledRetry = null;
 // Customise error for simple identification.
-function customError(errorDescription, error) {
-  return new Error(`n-feedback: ${errorDescription}`, error);
+function customError (errorDescription, error) {
+	return new Error(`n-feedback: ${errorDescription}`, error);
 }
 // Save response locally if the storage is supported and a response has not been stored yet.
-function saveResponse(surveyId, surveyData, surveyResponse, additionalData) {
-  if (
-    isStorageWritable &&
-    isStorageReadable &&
-    !storage.getItem(storageUniqueIdentifier)
-  ) {
-    try {
-      storage.setItem(
-        storageUniqueIdentifier,
-        JSON.stringify({ surveyId, surveyData, surveyResponse, additionalData })
-      );
-    } catch (error) {
-      // It shouldn't happen, but in case of error we log it.
-      throw customError(`unable to write on storage`, error);
-    }
-  }
+function saveResponse (surveyId, surveyData, surveyResponse, additionalData) {
+	if (
+		isStorageWritable &&
+		isStorageReadable &&
+		!storage.getItem(storageUniqueIdentifier)
+	) {
+		try {
+			storage.setItem(
+				storageUniqueIdentifier,
+				JSON.stringify({ surveyId, surveyData, surveyResponse, additionalData })
+			);
+		} catch (error) {
+			// It shouldn't happen, but in case of error we log it.
+			throw customError('unable to write on storage', error);
+		}
+	}
 }
 
-async function tryToSendResponse(
-  surveyId,
-  surveyData,
-  surveyResponse,
-  additionalData
+async function tryToSendResponse (
+	surveyId,
+	surveyData,
+	surveyResponse,
+	additionalData
 ) {
-  attempts++;
-  if (attempts > maxRetries) {
-    stopRetry();
-    return Promise.resolve(
-      `Reached the maximum amount of retries (${maxRetries})`
-    );
-  } else {
-    try {
-      await _postResponse(surveyId, surveyData, surveyResponse, additionalData);
-      stopAndClearLocalData();
-      return Promise.resolve(`Suceeded at attempts number ${attempts}`);
-    } catch (err) {
-      // Store data, if not already existing, in case we are not able to resolve the retries succesfully.
-      saveResponse(surveyId, surveyData, surveyResponse, additionalData);
-      return retryAfterTimeout(
-        surveyId,
-        surveyData,
-        surveyResponse,
-        additionalData
-      );
-    }
-  }
+	attempts++;
+	if (attempts > maxRetries) {
+		stopRetry();
+		return Promise.resolve(
+			`Reached the maximum amount of retries (${maxRetries})`
+		);
+	} else {
+		try {
+			await _postResponse(surveyId, surveyData, surveyResponse, additionalData);
+			stopAndClearLocalData();
+			return Promise.resolve(`Suceeded at attempts number ${attempts}`);
+		} catch (err) {
+			// Store data, if not already existing, in case we are not able to resolve the retries succesfully.
+			saveResponse(surveyId, surveyData, surveyResponse, additionalData);
+			return retryAfterTimeout(
+				surveyId,
+				surveyData,
+				surveyResponse,
+				additionalData
+			);
+		}
+	}
 }
 // setTimeout doesn't return (yet) a promise so we promisify it.
-async function retryAfterTimeout(
-  surveyId,
-  surveyData,
-  surveyResponse,
-  additionalData
+async function retryAfterTimeout (
+	surveyId,
+	surveyData,
+	surveyResponse,
+	additionalData
 ) {
-  return new Promise((resolve, reject) => {
-    scheduledRetry = setTimeout(async () => {
-      return tryToSendResponse(
-        surveyId,
-        surveyData,
-        surveyResponse,
-        additionalData
-      ).then(resolutionReason => {
-        resolve(resolutionReason);
-      });
-    }, intervalBetweenAttempts);
-  });
+	return new Promise((resolve) => {
+		scheduledRetry = setTimeout(async () => {
+			return tryToSendResponse(
+				surveyId,
+				surveyData,
+				surveyResponse,
+				additionalData
+			).then(resolutionReason => {
+				resolve(resolutionReason);
+			});
+		}, intervalBetweenAttempts);
+	});
 }
 
-function stopRetry() {
-  clearTimeout(scheduledRetry);
+function stopRetry () {
+	clearTimeout(scheduledRetry);
 }
 
-function clearData() {
-  return isStorageWritable && storage.removeItem(storageUniqueIdentifier);
+function clearData () {
+	return isStorageWritable && storage.removeItem(storageUniqueIdentifier);
 }
 
-function stopAndClearLocalData() {
-  clearData();
-  stopRetry();
+function stopAndClearLocalData () {
+	clearData();
+	stopRetry();
 }
 
 class StoreAndRetry {
-  constructor(config, bypassSingleton = false) {
-    if (!StoreAndRetry.instance || bypassSingleton) {
-      attempts = 0;
-      // Override defaults values.
-      maxRetries = config.maxRetries || defaultMaxRetries;
-      storage = config.storage || localStorage;
-      isStorageWritable = storage && typeof storage.setItem === "function";
-      isStorageReadable = storage && typeof storage.getItem === "function";
-      _postResponse = config.postResponse || _defaultPostResponse;
-      intervalBetweenAttempts =
-        config.intervalBetweenAttempts || defaultIntervalBetweenAttempts;
-      StoreAndRetry.instance = this;
-    }
-    return StoreAndRetry.instance;
-  }
+	constructor (config, bypassSingleton = false) {
+		if (!StoreAndRetry.instance || bypassSingleton) {
+			attempts = 0;
+			// Override defaults values.
+			maxRetries = config.maxRetries || defaultMaxRetries;
+			storage = config.storage || localStorage;
+			isStorageWritable = storage && typeof storage.setItem === 'function';
+			isStorageReadable = storage && typeof storage.getItem === 'function';
+			_postResponse = config.postResponse || _defaultPostResponse;
+			intervalBetweenAttempts =
+				config.intervalBetweenAttempts || defaultIntervalBetweenAttempts;
+			StoreAndRetry.instance = this;
+		}
+		return StoreAndRetry.instance;
+	}
 
-  async attemptToPostPrestoredResponses() {
-    const previousStoredResponse =
-      isStorageReadable && storage.getItem(storageUniqueIdentifier);
-    if (previousStoredResponse) {
-      const {
-        surveyId,
-        surveyData,
-        surveyResponse,
-        additionalData
-      } = JSON.parse(previousStoredResponse);
-      return tryToSendResponse(
-        surveyId,
-        surveyData,
-        surveyResponse,
-        additionalData
-      );
-    } else {
-      const resolutionReason = !isStorageReadable
-        ? "Storage not supported"
-        : "No previous stored response present";
-      return Promise.resolve(resolutionReason);
-    }
-  }
+	async attemptToPostPrestoredResponses () {
+		const previousStoredResponse =
+			isStorageReadable && storage.getItem(storageUniqueIdentifier);
+		if (previousStoredResponse) {
+			const {
+				surveyId,
+				surveyData,
+				surveyResponse,
+				additionalData
+			} = JSON.parse(previousStoredResponse);
+			return tryToSendResponse(
+				surveyId,
+				surveyData,
+				surveyResponse,
+				additionalData
+			);
+		} else {
+			const resolutionReason = !isStorageReadable
+				? 'Storage not supported'
+				: 'No previous stored response present';
+			return Promise.resolve(resolutionReason);
+		}
+	}
 
-  async postResponseWithRetry(
-    surveyId,
-    surveyData,
-    surveyResponse,
-    additionalData
-  ) {
-    return tryToSendResponse(
-      surveyId,
-      surveyData,
-      surveyResponse,
-      additionalData
-    );
-  }
+	async postResponseWithRetry (
+		surveyId,
+		surveyData,
+		surveyResponse,
+		additionalData
+	) {
+		return tryToSendResponse(
+			surveyId,
+			surveyData,
+			surveyResponse,
+			additionalData
+		);
+	}
 }
 
 module.exports = {
-  init(config, bypassSingleton) {
-    const instance = new StoreAndRetry(config, bypassSingleton);
-    Object.freeze(instance);
-    return instance;
-  }
+	init (config, bypassSingleton) {
+		const instance = new StoreAndRetry(config, bypassSingleton);
+		Object.freeze(instance);
+		return instance;
+	}
 };

--- a/src/lib/store-and-retry.js
+++ b/src/lib/store-and-retry.js
@@ -1,0 +1,170 @@
+/**
+ * This module produces a singleton to be use ad a service to provide fault tolerancy in case of network issue in the client.
+ * The module attempt to send a response of the survey and in case of failure will retry.
+ * Once loaded, the module will check if a pre-existent response was stored without been send, if it found the response it will try to send it again.
+ **/
+let _defaultPostResponse = require("../post-response");
+let _postResponse = null;
+// Number of retries before abandon.
+let defaultMaxRetries = 10;
+let maxRetries = null;
+// Time between attempts.
+const threeMinutesInMilliseconds = 180000;
+let defaultIntervalBetweenAttempts = threeMinutesInMilliseconds;
+let intervalBetweenAttempts = null;
+let storage = null;
+let isStorageWritable = null;
+let isStorageReadable = null;
+// Name for the key in the web storage.
+const storageUniqueIdentifier = "n-feedback-response";
+let attempts = null;
+let scheduledRetry = null;
+// Customise error for simple identification.
+function customError(errorDescription, error) {
+  return new Error(`n-feedback: ${errorDescription}`, error);
+}
+// Save response locally if the storage is supported and a response has not been stored yet.
+function saveResponse(surveyId, surveyData, surveyResponse, additionalData) {
+  if (
+    isStorageWritable &&
+    isStorageReadable &&
+    !storage.getItem(storageUniqueIdentifier)
+  ) {
+    try {
+      storage.setItem(
+        storageUniqueIdentifier,
+        JSON.stringify({ surveyId, surveyData, surveyResponse, additionalData })
+      );
+    } catch (error) {
+      // It shouldn't happen, but in case of error we log it.
+      throw customError(`unable to write on storage`, error);
+    }
+  }
+}
+
+async function tryToSendResponse(
+  surveyId,
+  surveyData,
+  surveyResponse,
+  additionalData
+) {
+  attempts++;
+  if (attempts > maxRetries) {
+    stopRetry();
+    return Promise.resolve(
+      `Reached the maximum amount of retries (${maxRetries})`
+    );
+  } else {
+    try {
+      await _postResponse(surveyId, surveyData, surveyResponse, additionalData);
+      stopAndClearLocalData();
+      return Promise.resolve(`Suceeded at attempts number ${attempts}`);
+    } catch (err) {
+      // Store data, if not already existing, in case we are not able to resolve the retries succesfully.
+      saveResponse(surveyId, surveyData, surveyResponse, additionalData);
+      return retryAfterTimeout(
+        surveyId,
+        surveyData,
+        surveyResponse,
+        additionalData
+      );
+    }
+  }
+}
+// setTimeout doesn't return (yet) a promise so we promisify it.
+async function retryAfterTimeout(
+  surveyId,
+  surveyData,
+  surveyResponse,
+  additionalData
+) {
+  return new Promise((resolve, reject) => {
+    scheduledRetry = setTimeout(async () => {
+      return tryToSendResponse(
+        surveyId,
+        surveyData,
+        surveyResponse,
+        additionalData
+      ).then(resolutionReason => {
+        resolve(resolutionReason);
+      });
+    }, intervalBetweenAttempts);
+  });
+}
+
+function stopRetry() {
+  clearTimeout(scheduledRetry);
+}
+
+function clearData() {
+  return isStorageWritable && storage.removeItem(storageUniqueIdentifier);
+}
+
+function stopAndClearLocalData() {
+  clearData();
+  stopRetry();
+}
+
+class StoreAndRetry {
+  constructor(config, bypassSingleton = false) {
+    if (!StoreAndRetry.instance || bypassSingleton) {
+      attempts = 0;
+      // Override defaults values.
+      maxRetries = config.maxRetries || defaultMaxRetries;
+      storage = config.storage || localStorage;
+      isStorageWritable = storage && typeof storage.setItem === "function";
+      isStorageReadable = storage && typeof storage.getItem === "function";
+      _postResponse = config.postResponse || _defaultPostResponse;
+      intervalBetweenAttempts =
+        config.intervalBetweenAttempts || defaultIntervalBetweenAttempts;
+      StoreAndRetry.instance = this;
+    }
+    return StoreAndRetry.instance;
+  }
+
+  async attemptToPostPrestoredResponses() {
+    const previousStoredResponse =
+      isStorageReadable && storage.getItem(storageUniqueIdentifier);
+    if (previousStoredResponse) {
+      const {
+        surveyId,
+        surveyData,
+        surveyResponse,
+        additionalData
+      } = JSON.parse(previousStoredResponse);
+      return tryToSendResponse(
+        surveyId,
+        surveyData,
+        surveyResponse,
+        additionalData
+      );
+    } else {
+      const resolutionReason = !isStorageReadable
+        ? "Storage not supported"
+        : "No previous stored response present";
+      return Promise.resolve(resolutionReason);
+    }
+  }
+
+  async postResponseWithRetry(
+    surveyId,
+    surveyData,
+    surveyResponse,
+    additionalData
+  ) {
+    return tryToSendResponse(
+      surveyId,
+      surveyData,
+      surveyResponse,
+      additionalData
+    );
+  }
+}
+
+module.exports = {
+  init(config, bypassSingleton) {
+    const instance = new StoreAndRetry(config, bypassSingleton);
+    Object.freeze(instance);
+    return instance;
+  }
+};

--- a/src/lib/store-and-retry.js
+++ b/src/lib/store-and-retry.js
@@ -106,7 +106,7 @@ function stopAndClearLocalData () {
 }
 
 class StoreAndRetry {
-	constructor (config, bypassSingleton = false) {
+	constructor (config = {}, bypassSingleton = false) {
 		if (!StoreAndRetry.instance || bypassSingleton) {
 			attempts = 0;
 			// Override defaults values.

--- a/test/lib/store-and-retry.spec.js
+++ b/test/lib/store-and-retry.spec.js
@@ -1,0 +1,261 @@
+const { expect } = require("chai");
+const storeAndRetry = require("../../src/lib/store-and-retry");
+const surveyId = "Survey123";
+const surveyData = "Are you happy today?";
+const surveyResponse = "Sort of...I think I need some holidays";
+const additionalData = "...that's life mate, that's life...";
+const defaultResponse = {
+  surveyId,
+  surveyData,
+  surveyResponse,
+  additionalData
+};
+
+describe.only("Store and retry", () => {
+  describe("provides fault tolerancy to not lose users feedbacks", () => {
+    describe("attemptToPostPrestoredResponses should be run on load", () => {
+      it("resolves immediately if there are no stored responses", done => {
+        // Empty storage.
+        let items = {};
+        const storageMock = {
+          getItem: key => items[key],
+          removeItem: key => delete items[key],
+          setItem: (key, value) => (items[key] = value)
+        };
+        const overrideDefaults = {
+          storage: storageMock
+        };
+        const storeAndRetryInstance = storeAndRetry.init(
+          overrideDefaults,
+          true
+        );
+        storeAndRetryInstance
+          .attemptToPostPrestoredResponses()
+          .then(expectedReasonForResolution => {
+            expect(expectedReasonForResolution).to.be.equal(
+              "No previous stored response present"
+            );
+            done();
+          });
+      });
+      it("resolves immediately if the storage is not supported so data cannot be stored", done => {
+        let items = {};
+        // getItem is removed to simulate not writable storage.
+        const storageMock = {
+          removeItem: key => delete items[key],
+          setItem: (key, value) => (items[key] = value)
+        };
+        const overrideDefaults = {
+          storage: storageMock
+        };
+        const storeAndRetryInstance = storeAndRetry.init(
+          overrideDefaults,
+          true
+        );
+        storeAndRetryInstance
+          .attemptToPostPrestoredResponses()
+          .then(expectedReasonForResolution => {
+            expect(expectedReasonForResolution).to.be.equal(
+              "Storage not supported"
+            );
+            done();
+          });
+      });
+      describe("if there is a stored response, attempt to send it again", () => {
+        it("it tries immediately, and if succeeded it clear the stored data", function(done) {
+          // Simulate the presence of previously stored data.
+          let items = {
+            "n-feedback-response": JSON.stringify(defaultResponse)
+          };
+          const storageMock = {
+            getItem: key => items[key],
+            removeItem: key => delete items[key],
+            setItem: (key, value) => (items[key] = value)
+          };
+          function postResponseMock() {
+            // Resolve at first attempt.
+            return Promise.resolve();
+          }
+          const overrideDefaults = {
+            storage: storageMock,
+            postResponse: postResponseMock
+          };
+          const storeAndRetryInstance = storeAndRetry.init(
+            overrideDefaults,
+            true
+          );
+          storeAndRetryInstance
+            .attemptToPostPrestoredResponses()
+            .then(expectedReasonForResolution => {
+              expect(storageMock.getItem("n-feedback-response")).to.be
+                .undefined;
+              expect(expectedReasonForResolution).to.be.equal(
+                "Suceeded at attempts number 1"
+              );
+              done();
+            });
+        });
+        it("if the network is not stable, it will retry, and if succeeded it clear the stored data", function(done) {
+          // Simulate the presence of previously stored data.
+          let items = {
+            "n-feedback-response": JSON.stringify(defaultResponse)
+          };
+          const storageMock = {
+            getItem: key => items[key],
+            removeItem: key => delete items[key],
+            setItem: (key, value) => (items[key] = value)
+          };
+
+          function* simulateUnstableNetwork() {
+            // First and second attempt will fail.
+            yield Promise.reject();
+            yield Promise.reject();
+            // Third attempt will succeed.
+            yield Promise.resolve();
+          }
+
+          const networkState = simulateUnstableNetwork();
+
+          function postResponseMock() {
+            // Wobbly connection...comes and goes.
+            return networkState.next().value;
+          }
+
+          const overrideDefaults = {
+            storage: storageMock,
+            postResponse: postResponseMock,
+            maxRetries: 5,
+            intervalBetweenAttempts: 10
+          };
+          const storeAndRetryInstance = storeAndRetry.init(
+            overrideDefaults,
+            true
+          );
+          storeAndRetryInstance
+            .attemptToPostPrestoredResponses()
+            .then(expectedReasonForResolution => {
+              expect(storageMock.getItem("n-feedback-response")).to.be
+                .undefined;
+              expect(expectedReasonForResolution).to.be.equal(
+                "Suceeded at attempts number 3"
+              );
+              done();
+            });
+        });
+        it("after a certain amount of time it will abandon but does not clear the stored data", function(done) {
+          // Simulate the presence of previously stored data.
+          let items = {
+            "n-feedback-response": JSON.stringify(defaultResponse)
+          };
+          const storageMock = {
+            getItem: key => items[key],
+            removeItem: key => delete items[key],
+            setItem: (key, value) => (items[key] = value)
+          };
+          function postResponseMock() {
+            // Consistently fails, you really should change network provider...
+            return Promise.reject();
+          }
+          const overrideDefaults = {
+            storage: storageMock,
+            postResponse: postResponseMock,
+            maxRetries: 5,
+            intervalBetweenAttempts: 10
+          };
+          const storeAndRetryInstance = storeAndRetry.init(
+            overrideDefaults,
+            true
+          );
+          storeAndRetryInstance
+            .attemptToPostPrestoredResponses()
+            .then(expectedReasonForResolution => {
+              expect(storageMock.getItem("n-feedback-response")).to.be.equal(
+                JSON.stringify(defaultResponse)
+              );
+              expect(expectedReasonForResolution).to.be.equal(
+                "Reached the maximum amount of retries (5)"
+              );
+              done();
+            });
+        });
+      });
+    });
+    describe("postResponseWithRetry", () => {
+      describe("programmatically try to post a response", () => {
+        it("if succeed it does not do anything else", done => {
+          let items = {
+            "n-feedback-response": JSON.stringify(defaultResponse)
+          };
+          const storageMock = {
+            getItem: key => items[key],
+            removeItem: key => delete items[key],
+            setItem: (key, value) => (items[key] = value)
+          };
+          function postResponseMock() {
+            // Resolve immediately, lucky day for the Customer Research Team.
+            return Promise.resolve();
+          }
+          const overrideDefaults = {
+            storage: storageMock,
+            postResponse: postResponseMock
+          };
+          let storeAndRetryInstance = null;
+          storeAndRetryInstance = storeAndRetry.init(overrideDefaults, true);
+
+          storeAndRetryInstance
+            .postResponseWithRetry(
+              surveyId,
+              surveyData,
+              surveyResponse,
+              additionalData
+            )
+            .then(expectedReasonForResolution => {
+              expect(expectedReasonForResolution).to.be.equal(
+                "Suceeded at attempts number 1"
+              );
+              // It shouldn't store anything if succeed.
+              expect(storageMock.getItem("n-feedback-response")).to.be
+                .undefined;
+              done();
+            });
+        });
+        it("if fails, it stores data locally as a precautionary measure for future attempts", done => {
+          let items = {
+            "n-feedback-response": JSON.stringify(defaultResponse)
+          };
+          const storageMock = {
+            getItem: key => items[key],
+            removeItem: key => delete items[key],
+            setItem: (key, value) => (items[key] = value)
+          };
+          function postResponseMock() {
+            // Offline...this will not end up well!!
+            return Promise.reject("You are offline");
+          }
+          const overrideDefaults = {
+            storage: storageMock,
+            postResponse: postResponseMock,
+            maxRetries: 2,
+            intervalBetweenAttempts: 10
+          };
+          let storeAndRetryInstance = null;
+          storeAndRetryInstance = storeAndRetry.init(overrideDefaults, true);
+
+          storeAndRetryInstance
+            .postResponseWithRetry(
+              surveyId,
+              surveyData,
+              surveyResponse,
+              additionalData
+            )
+            .then(expectedReasonForResolution => {
+              expect(storageMock.getItem("n-feedback-response")).to.be.equal(
+                JSON.stringify(defaultResponse)
+              );
+              done();
+            });
+        });
+      });
+    });
+  });
+});

--- a/test/lib/store-and-retry.spec.js
+++ b/test/lib/store-and-retry.spec.js
@@ -11,7 +11,7 @@ const defaultResponse = {
   additionalData
 };
 
-describe.only("Store and retry", () => {
+describe("Store and retry", () => {
   describe("provides fault tolerancy to not lose users feedbacks", () => {
     describe("attemptToPostPrestoredResponses should be run on load", () => {
       it("resolves immediately if there are no stored responses", done => {

--- a/test/lib/store-and-retry.spec.js
+++ b/test/lib/store-and-retry.spec.js
@@ -1,261 +1,261 @@
-const { expect } = require("chai");
-const storeAndRetry = require("../../src/lib/store-and-retry");
-const surveyId = "Survey123";
-const surveyData = "Are you happy today?";
-const surveyResponse = "Sort of...I think I need some holidays";
-const additionalData = "...that's life mate, that's life...";
+const { expect } = require('chai');
+const storeAndRetry = require('../../src/lib/store-and-retry');
+const surveyId = 'Survey123';
+const surveyData = 'Are you happy today?';
+const surveyResponse = 'Sort of...I think I need some holidays';
+const additionalData = '...that\'s life mate, that\'s life...';
 const defaultResponse = {
-  surveyId,
-  surveyData,
-  surveyResponse,
-  additionalData
+	surveyId,
+	surveyData,
+	surveyResponse,
+	additionalData
 };
 
-describe("Store and retry", () => {
-  describe("provides fault tolerancy to not lose users feedbacks", () => {
-    describe("attemptToPostPrestoredResponses should be run on load", () => {
-      it("resolves immediately if there are no stored responses", done => {
-        // Empty storage.
-        let items = {};
-        const storageMock = {
-          getItem: key => items[key],
-          removeItem: key => delete items[key],
-          setItem: (key, value) => (items[key] = value)
-        };
-        const overrideDefaults = {
-          storage: storageMock
-        };
-        const storeAndRetryInstance = storeAndRetry.init(
-          overrideDefaults,
-          true
-        );
-        storeAndRetryInstance
-          .attemptToPostPrestoredResponses()
-          .then(expectedReasonForResolution => {
-            expect(expectedReasonForResolution).to.be.equal(
-              "No previous stored response present"
-            );
-            done();
-          });
-      });
-      it("resolves immediately if the storage is not supported so data cannot be stored", done => {
-        let items = {};
-        // getItem is removed to simulate not writable storage.
-        const storageMock = {
-          removeItem: key => delete items[key],
-          setItem: (key, value) => (items[key] = value)
-        };
-        const overrideDefaults = {
-          storage: storageMock
-        };
-        const storeAndRetryInstance = storeAndRetry.init(
-          overrideDefaults,
-          true
-        );
-        storeAndRetryInstance
-          .attemptToPostPrestoredResponses()
-          .then(expectedReasonForResolution => {
-            expect(expectedReasonForResolution).to.be.equal(
-              "Storage not supported"
-            );
-            done();
-          });
-      });
-      describe("if there is a stored response, attempt to send it again", () => {
-        it("it tries immediately, and if succeeded it clear the stored data", function(done) {
-          // Simulate the presence of previously stored data.
-          let items = {
-            "n-feedback-response": JSON.stringify(defaultResponse)
-          };
-          const storageMock = {
-            getItem: key => items[key],
-            removeItem: key => delete items[key],
-            setItem: (key, value) => (items[key] = value)
-          };
-          function postResponseMock() {
-            // Resolve at first attempt.
-            return Promise.resolve();
-          }
-          const overrideDefaults = {
-            storage: storageMock,
-            postResponse: postResponseMock
-          };
-          const storeAndRetryInstance = storeAndRetry.init(
-            overrideDefaults,
-            true
-          );
-          storeAndRetryInstance
-            .attemptToPostPrestoredResponses()
-            .then(expectedReasonForResolution => {
-              expect(storageMock.getItem("n-feedback-response")).to.be
-                .undefined;
-              expect(expectedReasonForResolution).to.be.equal(
-                "Suceeded at attempts number 1"
-              );
-              done();
-            });
-        });
-        it("if the network is not stable, it will retry, and if succeeded it clear the stored data", function(done) {
-          // Simulate the presence of previously stored data.
-          let items = {
-            "n-feedback-response": JSON.stringify(defaultResponse)
-          };
-          const storageMock = {
-            getItem: key => items[key],
-            removeItem: key => delete items[key],
-            setItem: (key, value) => (items[key] = value)
-          };
+describe('Store and retry', () => {
+	describe('provides fault tolerancy to not lose users feedbacks', () => {
+		describe('attemptToPostPrestoredResponses should be run on load', () => {
+			it('resolves immediately if there are no stored responses', done => {
+				// Empty storage.
+				let items = {};
+				const storageMock = {
+					getItem: key => items[key],
+					removeItem: key => delete items[key],
+					setItem: (key, value) => (items[key] = value)
+				};
+				const overrideDefaults = {
+					storage: storageMock
+				};
+				const storeAndRetryInstance = storeAndRetry.init(
+					overrideDefaults,
+					true
+				);
+				storeAndRetryInstance
+					.attemptToPostPrestoredResponses()
+					.then(expectedReasonForResolution => {
+						expect(expectedReasonForResolution).to.be.equal(
+							'No previous stored response present'
+						);
+						done();
+					});
+			});
+			it('resolves immediately if the storage is not supported so data cannot be stored', done => {
+				let items = {};
+				// getItem is removed to simulate not writable storage.
+				const storageMock = {
+					removeItem: key => delete items[key],
+					setItem: (key, value) => (items[key] = value)
+				};
+				const overrideDefaults = {
+					storage: storageMock
+				};
+				const storeAndRetryInstance = storeAndRetry.init(
+					overrideDefaults,
+					true
+				);
+				storeAndRetryInstance
+					.attemptToPostPrestoredResponses()
+					.then(expectedReasonForResolution => {
+						expect(expectedReasonForResolution).to.be.equal(
+							'Storage not supported'
+						);
+						done();
+					});
+			});
+			describe('if there is a stored response, attempt to send it again', () => {
+				it('it tries immediately, and if succeeded it clear the stored data', function (done) {
+					// Simulate the presence of previously stored data.
+					let items = {
+						'n-feedback-response': JSON.stringify(defaultResponse)
+					};
+					const storageMock = {
+						getItem: key => items[key],
+						removeItem: key => delete items[key],
+						setItem: (key, value) => (items[key] = value)
+					};
+					function postResponseMock () {
+						// Resolve at first attempt.
+						return Promise.resolve();
+					}
+					const overrideDefaults = {
+						storage: storageMock,
+						postResponse: postResponseMock
+					};
+					const storeAndRetryInstance = storeAndRetry.init(
+						overrideDefaults,
+						true
+					);
+					storeAndRetryInstance
+						.attemptToPostPrestoredResponses()
+						.then(expectedReasonForResolution => {
+							expect(storageMock.getItem('n-feedback-response')).to.be
+								.undefined;
+							expect(expectedReasonForResolution).to.be.equal(
+								'Suceeded at attempts number 1'
+							);
+							done();
+						});
+				});
+				it('if the network is not stable, it will retry, and if succeeded it clear the stored data', function (done) {
+					// Simulate the presence of previously stored data.
+					let items = {
+						'n-feedback-response': JSON.stringify(defaultResponse)
+					};
+					const storageMock = {
+						getItem: key => items[key],
+						removeItem: key => delete items[key],
+						setItem: (key, value) => (items[key] = value)
+					};
 
-          function* simulateUnstableNetwork() {
-            // First and second attempt will fail.
-            yield Promise.reject();
-            yield Promise.reject();
-            // Third attempt will succeed.
-            yield Promise.resolve();
-          }
+					function* simulateUnstableNetwork () {
+						// First and second attempt will fail.
+						yield Promise.reject();
+						yield Promise.reject();
+						// Third attempt will succeed.
+						yield Promise.resolve();
+					}
 
-          const networkState = simulateUnstableNetwork();
+					const networkState = simulateUnstableNetwork();
 
-          function postResponseMock() {
-            // Wobbly connection...comes and goes.
-            return networkState.next().value;
-          }
+					function postResponseMock () {
+						// Wobbly connection...comes and goes.
+						return networkState.next().value;
+					}
 
-          const overrideDefaults = {
-            storage: storageMock,
-            postResponse: postResponseMock,
-            maxRetries: 5,
-            intervalBetweenAttempts: 10
-          };
-          const storeAndRetryInstance = storeAndRetry.init(
-            overrideDefaults,
-            true
-          );
-          storeAndRetryInstance
-            .attemptToPostPrestoredResponses()
-            .then(expectedReasonForResolution => {
-              expect(storageMock.getItem("n-feedback-response")).to.be
-                .undefined;
-              expect(expectedReasonForResolution).to.be.equal(
-                "Suceeded at attempts number 3"
-              );
-              done();
-            });
-        });
-        it("after a certain amount of time it will abandon but does not clear the stored data", function(done) {
-          // Simulate the presence of previously stored data.
-          let items = {
-            "n-feedback-response": JSON.stringify(defaultResponse)
-          };
-          const storageMock = {
-            getItem: key => items[key],
-            removeItem: key => delete items[key],
-            setItem: (key, value) => (items[key] = value)
-          };
-          function postResponseMock() {
-            // Consistently fails, you really should change network provider...
-            return Promise.reject();
-          }
-          const overrideDefaults = {
-            storage: storageMock,
-            postResponse: postResponseMock,
-            maxRetries: 5,
-            intervalBetweenAttempts: 10
-          };
-          const storeAndRetryInstance = storeAndRetry.init(
-            overrideDefaults,
-            true
-          );
-          storeAndRetryInstance
-            .attemptToPostPrestoredResponses()
-            .then(expectedReasonForResolution => {
-              expect(storageMock.getItem("n-feedback-response")).to.be.equal(
-                JSON.stringify(defaultResponse)
-              );
-              expect(expectedReasonForResolution).to.be.equal(
-                "Reached the maximum amount of retries (5)"
-              );
-              done();
-            });
-        });
-      });
-    });
-    describe("postResponseWithRetry", () => {
-      describe("programmatically try to post a response", () => {
-        it("if succeed it does not do anything else", done => {
-          let items = {
-            "n-feedback-response": JSON.stringify(defaultResponse)
-          };
-          const storageMock = {
-            getItem: key => items[key],
-            removeItem: key => delete items[key],
-            setItem: (key, value) => (items[key] = value)
-          };
-          function postResponseMock() {
-            // Resolve immediately, lucky day for the Customer Research Team.
-            return Promise.resolve();
-          }
-          const overrideDefaults = {
-            storage: storageMock,
-            postResponse: postResponseMock
-          };
-          let storeAndRetryInstance = null;
-          storeAndRetryInstance = storeAndRetry.init(overrideDefaults, true);
+					const overrideDefaults = {
+						storage: storageMock,
+						postResponse: postResponseMock,
+						maxRetries: 5,
+						intervalBetweenAttempts: 10
+					};
+					const storeAndRetryInstance = storeAndRetry.init(
+						overrideDefaults,
+						true
+					);
+					storeAndRetryInstance
+						.attemptToPostPrestoredResponses()
+						.then(expectedReasonForResolution => {
+							expect(storageMock.getItem('n-feedback-response')).to.be
+								.undefined;
+							expect(expectedReasonForResolution).to.be.equal(
+								'Suceeded at attempts number 3'
+							);
+							done();
+						});
+				});
+				it('after a certain amount of time it will abandon but does not clear the stored data', function (done) {
+					// Simulate the presence of previously stored data.
+					let items = {
+						'n-feedback-response': JSON.stringify(defaultResponse)
+					};
+					const storageMock = {
+						getItem: key => items[key],
+						removeItem: key => delete items[key],
+						setItem: (key, value) => (items[key] = value)
+					};
+					function postResponseMock () {
+						// Consistently fails, you really should change network provider...
+						return Promise.reject();
+					}
+					const overrideDefaults = {
+						storage: storageMock,
+						postResponse: postResponseMock,
+						maxRetries: 5,
+						intervalBetweenAttempts: 10
+					};
+					const storeAndRetryInstance = storeAndRetry.init(
+						overrideDefaults,
+						true
+					);
+					storeAndRetryInstance
+						.attemptToPostPrestoredResponses()
+						.then(expectedReasonForResolution => {
+							expect(storageMock.getItem('n-feedback-response')).to.be.equal(
+								JSON.stringify(defaultResponse)
+							);
+							expect(expectedReasonForResolution).to.be.equal(
+								'Reached the maximum amount of retries (5)'
+							);
+							done();
+						});
+				});
+			});
+		});
+		describe('postResponseWithRetry', () => {
+			describe('programmatically try to post a response', () => {
+				it('if succeed it does not do anything else', done => {
+					let items = {
+						'n-feedback-response': JSON.stringify(defaultResponse)
+					};
+					const storageMock = {
+						getItem: key => items[key],
+						removeItem: key => delete items[key],
+						setItem: (key, value) => (items[key] = value)
+					};
+					function postResponseMock () {
+						// Resolve immediately, lucky day for the Customer Research Team.
+						return Promise.resolve();
+					}
+					const overrideDefaults = {
+						storage: storageMock,
+						postResponse: postResponseMock
+					};
+					let storeAndRetryInstance = null;
+					storeAndRetryInstance = storeAndRetry.init(overrideDefaults, true);
 
-          storeAndRetryInstance
-            .postResponseWithRetry(
-              surveyId,
-              surveyData,
-              surveyResponse,
-              additionalData
-            )
-            .then(expectedReasonForResolution => {
-              expect(expectedReasonForResolution).to.be.equal(
-                "Suceeded at attempts number 1"
-              );
-              // It shouldn't store anything if succeed.
-              expect(storageMock.getItem("n-feedback-response")).to.be
-                .undefined;
-              done();
-            });
-        });
-        it("if fails, it stores data locally as a precautionary measure for future attempts", done => {
-          let items = {
-            "n-feedback-response": JSON.stringify(defaultResponse)
-          };
-          const storageMock = {
-            getItem: key => items[key],
-            removeItem: key => delete items[key],
-            setItem: (key, value) => (items[key] = value)
-          };
-          function postResponseMock() {
-            // Offline...this will not end up well!!
-            return Promise.reject("You are offline");
-          }
-          const overrideDefaults = {
-            storage: storageMock,
-            postResponse: postResponseMock,
-            maxRetries: 2,
-            intervalBetweenAttempts: 10
-          };
-          let storeAndRetryInstance = null;
-          storeAndRetryInstance = storeAndRetry.init(overrideDefaults, true);
+					storeAndRetryInstance
+						.postResponseWithRetry(
+							surveyId,
+							surveyData,
+							surveyResponse,
+							additionalData
+						)
+						.then(expectedReasonForResolution => {
+							expect(expectedReasonForResolution).to.be.equal(
+								'Suceeded at attempts number 1'
+							);
+							// It shouldn't store anything if succeed.
+							expect(storageMock.getItem('n-feedback-response')).to.be
+								.undefined;
+							done();
+						});
+				});
+				it('if fails, it stores data locally as a precautionary measure for future attempts', done => {
+					let items = {
+						'n-feedback-response': JSON.stringify(defaultResponse)
+					};
+					const storageMock = {
+						getItem: key => items[key],
+						removeItem: key => delete items[key],
+						setItem: (key, value) => (items[key] = value)
+					};
+					function postResponseMock () {
+						// Offline...this will not end up well!!
+						return Promise.reject('You are offline');
+					}
+					const overrideDefaults = {
+						storage: storageMock,
+						postResponse: postResponseMock,
+						maxRetries: 2,
+						intervalBetweenAttempts: 10
+					};
+					let storeAndRetryInstance = null;
+					storeAndRetryInstance = storeAndRetry.init(overrideDefaults, true);
 
-          storeAndRetryInstance
-            .postResponseWithRetry(
-              surveyId,
-              surveyData,
-              surveyResponse,
-              additionalData
-            )
-            .then(expectedReasonForResolution => {
-              expect(storageMock.getItem("n-feedback-response")).to.be.equal(
-                JSON.stringify(defaultResponse)
-              );
-              done();
-            });
-        });
-      });
-    });
-  });
+					storeAndRetryInstance
+						.postResponseWithRetry(
+							surveyId,
+							surveyData,
+							surveyResponse,
+							additionalData
+						)
+						.then(() => {
+							expect(storageMock.getItem('n-feedback-response')).to.be.equal(
+								JSON.stringify(defaultResponse)
+							);
+							done();
+						});
+				});
+			});
+		});
+	});
 });


### PR DESCRIPTION
This PR is meant to resolve this issue https://github.com/Financial-Times/next-feedback-api/issues/46 

## Test Plan
I add here the test plan to verify this implementation also in the App (With relevant titles):

### That strange moment when everything goes well
GIVEN I'm a user
WHEN  I submit a survey response via the Universal survey and I'm online
THEN the survey is submitted correctly

### That morningly moment when you are arriving at Elephant and Castle in 5 minutes
GIVEN I'm a user
WHEN  I submit a survey response via the Universal survey and I'm temporarily offline
THEN after 5 mins I go online again and the survey is submitted correctly

### That nightly moment when you are in the tube but you want to give your feedback to FT at any cost, but still, we are smart and wait till you arrive home
GIVEN I'm a user
WHEN  I submit a survey response via the Universal survey and I'm offline
THEN I close the browser/App and I have some `spaghetti alla carbonara` and I realise that there is another Brexit vote and I re-open the App/Browser with the FT and the survey is submitted correctly
