### PR TITLE
Changes h3 to h2 for survey heading

### DIFF
--- a/src/survey-builder.js
+++ b/src/survey-builder.js
@@ -2,7 +2,7 @@
 const dictionary = require('./dictionary');
 
 function buildHeader (question) {
-	return `<div class="n-feedback__center-block"><h3 class="n-feedback__question-header">${question.questionText}</h3></div>`;
+	return `<div class="n-feedback__center-block"><h2 class="n-feedback__question-header">${question.questionText}</h2></div>`;
 }
 
 function buildText (question) {


### PR DESCRIPTION
 🐿 v2.12.3

This PR is for accessibility issues. I believe I understood it correctly:

```
The “How easy or hard was it to use FT.com today?”' heading is tagged under the incorrect heading level i.e., 3.
Instead of using <h3> having class="n-feedback__question-header", use <h2> or provide role="heading" aria-level="2" to the <h3>.
```

https://docs.google.com/spreadsheets/d/1_Wp100e-2gwGQDxPS6YODqFsVRwycO9Y6PiXzppU-TY/edit?ts=5cd598dd#gid=2122682530&fvid=1728983758