### PR TITLE
Add Snyk to components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
+      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/n-feedback
       - run:
           name: shared-helper / npm-version-and-publish-public
           command: .circleci/shared-helpers/helper-npm-version-and-publish-public

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
+version: v1.13.5
+ignore: {}
+patch: {}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "commit": "commit-wizard",
     "precommit": "node_modules/.bin/secret-squirrel",
     "prepush": "make verify -j3",
-    "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg"
+    "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.4.2",
@@ -31,6 +32,7 @@
     "nodemon": "^1.17.3",
     "npm-prepublish": "^1.2.2",
     "proxyquire": "^2.1.0",
+    "snyk": "^1.167.2",
     "webpack": "^4.6.0",
     "webpack-cli": "^3.1.2"
   },


### PR DESCRIPTION
We are installing [Snyk](https://snyk.io) in all of our repos for security reasons. It will patch or ignore known vulnerabilities. Currently Snyk is enabled on our repos (config and results can be viewed from the Snyk webpage) but we want to install it on each project for increased security when building. See https://github.com/Financial-Times/next/issues/365