### PR TITLE
Fix contrast of radio buttons

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "n-ui-foundations": "^3.0.0",
     "o-overlay": "^2.4.2",
     "o-buttons": "^5.11.6",
-    "o-forms": "^6.0.0",
+    "o-forms": "^7.0.0",
     "o-loading": "^3.0.0",
     "o-typography": "^5.9.0"
   }

--- a/main.scss
+++ b/main.scss
@@ -6,16 +6,22 @@
 @import 'o-typography/main';
 @import 'o-loading/main';
 
-@include oFormsBaseFeatures();
-@include oFormsRadioCheckboxFeatures();
-
 @mixin centerForm {
 	max-width: 380px;
 	margin: 0 auto;
 }
 
+@include oForms($opts: (
+	'elements': (
+		'radio-round'
+	),
+	'features': (
+		'small'
+	)
+));
+
 // Desktop styles
-@include oGridRespondTo($from: M){
+@include oGridRespondTo($from: M) {
 	.n-feedback__container {
 		.n-feedback__survey-trigger {
 			z-index: 1000;
@@ -63,7 +69,7 @@
 }
 
 // Mobile only styles
-@include oGridRespondTo($until: M){
+@include oGridRespondTo($until: M) {
 	.feedback-overlay {
 		top: 0;
 		z-index: 110;
@@ -144,43 +150,47 @@
 	}
 
 	.n-feedback__question-radio {
+		display: block;
 		border-top: 1px solid oColorsGetPaletteColor('slate');
 		border-bottom: 1px solid oColorsGetPaletteColor('slate');
 		border-left: none;
 		border-right: none;
 		padding: 1em 0 0.4em 0;
+		margin-bottom: 0;
 
-		legend {
+		@include oGridRespondTo($until: S) {
+			display: flex;
+		}
+
+		.o-forms-title__main {
 			@include oNormaliseVisuallyHidden;
 		}
 
-		.n-feedback__question-radio__container {
-			@include oFormsGroup();
-			display: flex;
-			margin-top: 0;
-			margin-bottom: 0;
-			padding: 0 0 10px 10px;
+		.n-feedback__question-radio__outer-container {
+			@include centerForm;
+		}
 
-			@include oGridRespondTo($until: M){
-				@include centerForm;
-			}
+		.n-feedback__question-radio__container {
+			display: flex;
+			justify-content: space-around;
+			padding: 0 10px;
+			margin: 0;
 		}
 
 		.n-feedback__question-radio__choice-container {
-			flex-grow: 1;
 			text-align: center;
 		}
 
-		label {
+		.hidden-label span {
+			@include oNormaliseVisuallyHidden;
+		}
+
+		.o-forms-input__label {
 			span {
 				display: block;
 				margin-left: -50px;
 				margin-top: 30px;
 			}
-		}
-
-		.hidden-label span {
-			@include oNormaliseVisuallyHidden;
 		}
 	}
 

--- a/src/survey-builder.js
+++ b/src/survey-builder.js
@@ -35,10 +35,13 @@ function buildMultipleChoiceQuestion (question) {
 	const validation = question.validation.doesForceResponse;
 
 	const html = [
-		`<fieldset class="n-feedback__question-radio" data-validation=${validation}>
-			<legend>${question.questionText}</legend>
-			<div class="n-feedback__question-radio__container n-feedback__center-block">`
-	]; // fieldsets can't display: flex
+		`<div class="n-feedback__question-radio o-forms-field" role="group" aria-labelledby="n-feedback-form-question-title" data-validation=${validation}>
+			<span class="o-forms-title" aria-hidden="true">
+				<span class="o-forms-title__main" id="n-feedback-form-question-title">${question.questionText}</span>
+			</span>
+			<div class="n-feedback__question-radio__outer-container">
+				<span class="n-feedback__question-radio__container n-feedback__center-block o-forms-input o-forms-input--radio-round o-forms-input--inline">`
+	];
 
 	const choices = Object.entries(question.choices).reverse();
 
@@ -51,16 +54,20 @@ function buildMultipleChoiceQuestion (question) {
 		const fieldId = `choice-${choiceId}-${~~(Math.random()*0xffff)}`;
 
 		html.push(
-			`<div class="n-feedback__question-radio__choice-container">
-				<input type="radio" id="${fieldId}" class="o-forms__radio" name="${question.questionId}" value="${choiceId}" />
-				<label for="${fieldId}" class="o-forms__label ${textVisibility}">
-					<span class="n-feedback__question-radio-text">${choice.choiceText}</span>
-				</label>
-			</div>`
+			`<label class="n-feedback__question-radio__choice-container">
+				<input type="radio" id="${fieldId}" name="${question.questionId}" value="${choiceId}" aria-label="${choice.choiceText}">
+				<span class="o-forms-input__label ${textVisibility}" aria-hidden="true">
+					<span>${choice.choiceText}</span>
+				</span>
+			</label>`
 		);
 	});
 
-	html.push('</div></fieldset>');
+	html.push(`
+				</span>
+			</div>
+		</div>`
+	);
 	return html.join('\n');
 }
 


### PR DESCRIPTION
In order to fix the contrast of the radio buttons on the feedback form, I've upgraded to `o-forms` v7 ([migration guide](https://github.com/Financial-Times/o-forms/blob/v7.0.3/MIGRATION.md#migrating-from-v6-to-v7))

Some differences with existing styles

* ~~There is a square around the round radio button when focused, where as the existing one has a circle outline~~ (this is fixed with `o-forms@7.0.6`)
* The html/css needed a bit of tweaking to get it right for `o-forms` v7.

  Specifically:

  * Needed to add an extra `div.n-feedback__question-radio__outer-container` to overcome the issue of `display: flex` not expanding spaces evenly when there is a `margin: 0 auto` used.
  * Used `display: block` on `.n-feedback__question-radio` by default for dynamic spacing around the labels. For screens less than small, `display: flex` is used, which gives it fixed spacing, but will prevent the form field from running off the screen on the left.


  A html/css playground for getting the styling right is here: https://codepen.io/taktran/pen/gJNVLN

See https://trello.com/c/Fakhcdrf/102-dacnon-textcontrastissue3