### PR TITLE
Upgrade o-forms to v7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "n-ui-foundations": "^3.0.0",
     "o-overlay": "^2.4.2",
     "o-buttons": "^5.11.6",
-    "o-forms": "^6.0.0",
+    "o-forms": "^7.0.0",
     "o-loading": "^3.0.0",
     "o-typography": "^5.9.0"
   }

--- a/main.scss
+++ b/main.scss
@@ -6,16 +6,22 @@
 @import 'o-typography/main';
 @import 'o-loading/main';
 
-@include oFormsBaseFeatures();
-@include oFormsRadioCheckboxFeatures();
-
 @mixin centerForm {
 	max-width: 380px;
 	margin: 0 auto;
 }
 
+@include oForms($opts: (
+	'elements': (
+		'radio-round'
+	),
+	'features': (
+		'small'
+	)
+));
+
 // Desktop styles
-@include oGridRespondTo($from: M){
+@include oGridRespondTo($from: M) {
 	.n-feedback__container {
 		.n-feedback__survey-trigger {
 			z-index: 1000;
@@ -63,7 +69,7 @@
 }
 
 // Mobile only styles
-@include oGridRespondTo($until: M){
+@include oGridRespondTo($until: M) {
 	.feedback-overlay {
 		top: 0;
 		z-index: 110;
@@ -144,43 +150,47 @@
 	}
 
 	.n-feedback__question-radio {
+		display: block;
 		border-top: 1px solid oColorsGetPaletteColor('slate');
 		border-bottom: 1px solid oColorsGetPaletteColor('slate');
 		border-left: none;
 		border-right: none;
 		padding: 1em 0 0.4em 0;
+		margin-bottom: 0;
 
-		legend {
+		@include oGridRespondTo($until: S) {
+			display: flex;
+		}
+
+		.o-forms-title__main {
 			@include oNormaliseVisuallyHidden;
 		}
 
-		.n-feedback__question-radio__container {
-			@include oFormsGroup();
-			display: flex;
-			margin-top: 0;
-			margin-bottom: 0;
-			padding: 0 0 10px 10px;
+		.n-feedback__question-radio__outer-container {
+			@include centerForm;
+		}
 
-			@include oGridRespondTo($until: M){
-				@include centerForm;
-			}
+		.n-feedback__question-radio__container {
+			display: flex;
+			justify-content: space-around;
+			padding: 0 10px;
+			margin: 0;
 		}
 
 		.n-feedback__question-radio__choice-container {
-			flex-grow: 1;
 			text-align: center;
 		}
 
-		label {
+		.hidden-label span {
+			@include oNormaliseVisuallyHidden;
+		}
+
+		.o-forms-input__label {
 			span {
 				display: block;
 				margin-left: -50px;
 				margin-top: 30px;
 			}
-		}
-
-		.hidden-label span {
-			@include oNormaliseVisuallyHidden;
 		}
 	}
 

--- a/src/survey-builder.js
+++ b/src/survey-builder.js
@@ -35,10 +35,13 @@ function buildMultipleChoiceQuestion (question) {
 	const validation = question.validation.doesForceResponse;
 
 	const html = [
-		`<fieldset class="n-feedback__question-radio" data-validation=${validation}>
-			<legend>${question.questionText}</legend>
-			<div class="n-feedback__question-radio__container n-feedback__center-block">`
-	]; // fieldsets can't display: flex
+		`<div class="n-feedback__question-radio o-forms-field" role="group" aria-labelledby="n-feedback-form-question-title" data-validation=${validation}>
+			<span class="o-forms-title" aria-hidden="true">
+				<span class="o-forms-title__main" id="n-feedback-form-question-title">${question.questionText}</span>
+			</span>
+			<div class="n-feedback__question-radio__outer-container">
+				<span class="n-feedback__question-radio__container n-feedback__center-block o-forms-input o-forms-input--radio-round o-forms-input--inline">`
+	];
 
 	const choices = Object.entries(question.choices).reverse();
 
@@ -51,16 +54,20 @@ function buildMultipleChoiceQuestion (question) {
 		const fieldId = `choice-${choiceId}-${~~(Math.random()*0xffff)}`;
 
 		html.push(
-			`<div class="n-feedback__question-radio__choice-container">
-				<input type="radio" id="${fieldId}" class="o-forms__radio" name="${question.questionId}" value="${choiceId}" />
-				<label for="${fieldId}" class="o-forms__label ${textVisibility}">
-					<span class="n-feedback__question-radio-text">${choice.choiceText}</span>
-				</label>
-			</div>`
+			`<label class="n-feedback__question-radio__choice-container">
+				<input type="radio" id="${fieldId}" name="${question.questionId}" value="${choiceId}" aria-label="${choice.choiceText}">
+				<span class="o-forms-input__label ${textVisibility}" aria-hidden="true">
+					<span>${choice.choiceText}</span>
+				</span>
+			</label>`
 		);
 	});
 
-	html.push('</div></fieldset>');
+	html.push(`
+				</span>
+			</div>
+		</div>`
+	);
 	return html.join('\n');
 }
 


### PR DESCRIPTION
⚠️ Merging and releasing this will force all `n-ui` components to update to `o-forms@v7`, so do it with caution (see [discussion](https://financialtimes.slack.com/archives/C041V9QA7/p1560337094133700)) ⚠️ 
ℹ️ Also, release this as a *major* version, as it is a breaking change

This reverts commit b1992d07291445900863dd689f1d5e8f5fecbd2b.
Which is basically reinstating edecc6f82b7d61d6ea3eeb9c4bad39782527ec15.

Needed to release a patch release([v4.6.1](https://github.com/Financial-Times/n-feedback/releases/tag/v4.6.1)) before we release this as a major update.

Related to
https://github.com/Financial-Times/n-feedback/pull/68
https://github.com/Financial-Times/n-feedback/pull/70

