### PR TITLE
Refactor to remove formdata polyfill

### DIFF
--- a/demos/app.js
+++ b/demos/app.js
@@ -26,6 +26,14 @@ app.get('/', (req, res) => {
 	});
 });
 
+app.get('/simple', (req, res) => {
+	res.render('demo-simple', {
+		title: 'Test App',
+		question: 'How was your visit today?',
+		type: 'radio-buttons'
+	});
+});
+
 function runPa11yTests () {
 	const spawn = require('child_process').spawn;
 	const pa11y = spawn('pa11y-ci');

--- a/demos/demo-simple.html
+++ b/demos/demo-simple.html
@@ -9,7 +9,7 @@
 <div class="o-grid-container">
 	<h1>Demo of n-feedback</h1>
 	<div class="o-grid-row">
-		{{> template }}
+		{{> demos/feedback-partial }}
 	</div>
 </div>
 <script src="/public/main.js"></script>

--- a/index.js
+++ b/index.js
@@ -120,26 +120,27 @@ function validate (block){
 function generateResponse (overlay){
 	const context = overlay.content;
 	const form = document.querySelector('.n-feedback__survey__wrapper-form', context);
-	const formInputs = form.getElementsByTagName('input');
-	const formTextArea = form.getElementsByTagName('textArea');
-	const questionID = formInputs.item(1).name;
-	const textFieldId = formTextArea.item(0).name;
-	const textFieldValue = formTextArea.item(0).value;
-	let formSurveyId;
-	let formChecked;
+	const data = {};
 
-	for (let i = 0; i < formInputs.length; i++) {
-		if (formInputs[i].name === 'surveyId') { formSurveyId = formInputs[i].value; }
-		if (formInputs[i].checked === true) { formChecked = formInputs[i].value; }
-	}
+	form.querySelectorAll('input,textarea').forEach((element) => {
+		if (element.type === 'radio') {
+			if (element.checked) {
+				data[element.name] = element.value;
+			}
+		}
 
-	const response = {
-		surveyId: formSurveyId,
-		[questionID]: formChecked,
-		[textFieldId]: textFieldValue
-	};
+		else if (element.type === 'checkbox') {
+			if (element.checked) {
+				data[element.name] = (data[element.name] || []).concat(element.value);
+			}
+		}
 
-	return response;
+		else {
+			data[element.name] = element.value;
+		}
+	});
+
+	return data;
 }
 
 function toggleOverlay (overlay){

--- a/index.js
+++ b/index.js
@@ -3,12 +3,11 @@ const surveyBuilder = require('./src/survey-builder');
 const postResponse = require('./src/post-response');
 const getAdditionalInfo = require('./src/get-additional-info');
 const dictionary = require('./src/dictionary');
-require('formdata-polyfill');
 
 function getSurveyData ( surveyId ){
-	// const surveyDataURL = 'http://local.ft.com:5005/public/survey.json';
-	// const surveyDataURL = `http://local.ft.com:3002/v1/survey/${surveyId}`;
-	const surveyDataURL = `https://www.ft.com/__feedback-api/v1/survey/${surveyId}`;
+	// const surveyDataURL = 'http://local.ft.com:5005/public/survey.json'; // for local development
+	// const surveyDataURL = `http://local.ft.com:3002/v1/survey/${surveyId}`; // for local development via npm linking
+	const surveyDataURL = `https://www.ft.com/__feedback-api/v1/survey/${surveyId}`; // production link
 	return fetch(surveyDataURL, {
 		headers: {
 			'Accept': 'application/json',
@@ -121,10 +120,24 @@ function validate (block){
 function generateResponse (overlay){
 	const context = overlay.content;
 	const form = document.querySelector('.n-feedback__survey__wrapper-form', context);
-	const response = {};
-	(new FormData(form)).forEach((val, key) => {
-		response[key] = val;
-	});
+	const formInputs = form.getElementsByTagName('input');
+	const formTextArea = form.getElementsByTagName('textArea');
+	const questionID = formInputs.item(1).name;
+	const textFieldId = formTextArea.item(0).name;
+	const textFieldValue = formTextArea.item(0).value;
+	let formSurveyId;
+	let formChecked;
+
+	for (let i = 0; i < formInputs.length; i++) {
+		if (formInputs[i].name === 'surveyId') { formSurveyId = formInputs[i].value; }
+		if (formInputs[i].checked === true) { formChecked = formInputs[i].value; }
+	}
+
+	const response = {
+		surveyId: formSurveyId,
+		[questionID]: formChecked,
+		[textFieldId]: textFieldValue
+	};
 
 	return response;
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "webpack-cli": "^3.1.2"
   },
   "dependencies": {
-    "formdata-polyfill": "^3.0.12",
     "handlebars": "^4.1.2"
   }
 }


### PR DESCRIPTION
Our current Page Kit migration path includes a step to make `formdata-polyfill` an app dependency in order to support the current implementation of n-feedback. 

In order to avoid introducing this dependency widely in our applications, this PR refactors the way data is collected from our onsite feedback form - removing our dependence on `FormData` and its polyfill. 

Closes https://github.com/Financial-Times/n-feedback/issues/75 and https://github.com/Financial-Times/dotcom-page-kit/issues/547