### PR TITLE
Update the way appName is fetched to match page kit context

### DIFF
--- a/src/get-additional-info.js
+++ b/src/get-additional-info.js
@@ -5,15 +5,16 @@ function getAdditionalInfo (appInfo) {
 	} = document;
 
 	const {
-		name: appName,
+		appName,
 		product,
 		version,
 		nativeAppVersion,
 		domain
 	} = appInfo;
 
-	const additionalInfo = {
-		appName,
+		const additionalInfo = {
+		// TODO: Once Page Kit has been rolled out across all apps, this appInfo.name bit should be removed.
+		appName: appName || appInfo.name,
 		currentUrl,
 		referrerUrl,
 		product,

--- a/test/get-additional-info.spec.js
+++ b/test/get-additional-info.spec.js
@@ -10,7 +10,7 @@ describe('getAdditionalInfo()', () => {
 	};
 	const { document } = (new JSDOM('', domOptions)).window;
 	const appInfo = {
-		name: 'stream'
+		appName: 'stream'
 	};
 
 	let originalDoc;
@@ -39,6 +39,11 @@ describe('getAdditionalInfo()', () => {
 	});
 
 	it('should return the app name from the app info it receives', () => {
+		expect(additionalInfo.appName).to.equal('stream');
+	});
+
+	it('LEGACY: should also return the app name from the pre-page-kit app info it receives', () => {
+		additionalInfo = getAdditionalInfo({ name: 'stream' });
 		expect(additionalInfo.appName).to.equal('stream');
 	});
 });


### PR DESCRIPTION
🐿 v2.12.5

This seems to have changed with PageKit as `appInfo.appName` is now passed in.