### PR TITLE
Switch to using o-overlay on npm instead of bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,6 @@
   "main": "index.js",
   "dependencies": {
     "n-ui-foundations": "^3.0.0",
-    "o-overlay": "^2.7.5",
     "o-buttons": "^5.11.6",
     "o-forms": "^6.0.0",
     "o-loading": "^3.0.0",

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const Overlay = require('o-overlay');
+const Overlay = require('@financial-times/o-overlay');
 const surveyBuilder = require('./src/survey-builder');
 const postResponse = require('./src/post-response');
 const getAdditionalInfo = require('./src/get-additional-info');

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "webpack-cli": "^3.1.2"
   },
   "dependencies": {
+    "@financial-times/o-overlay": "^2.7.11",
     "handlebars": "^4.1.2"
   }
 }


### PR DESCRIPTION
Membership are trying to implement this on https://github.com/Financial-Times/m-login, but because that's not built on the Next stack they're having difficulties doing so. One of which being that they don't have bower set up in the workflow _at all_.

Since Origami components are available on npm as well, it's much easier to just do that here.

🐿 v2.12.5