### PR TITLE
 ACC-423-Accessibility issue with Feedback radio buttons 🐿 v2.13.0

### DIFF
--- a/src/survey-builder.js
+++ b/src/survey-builder.js
@@ -35,8 +35,8 @@ function buildMultipleChoiceQuestion (question) {
 	const validation = question.validation.doesForceResponse;
 
 	const html = [
-		`<fieldset class="n-feedback__question-radio" data-validation=${validation}>
-			<legend>${question.questionText}</legend>
+		`<fieldset class="n-feedback__question-radio" data-validation=${validation} role="radiogroup" aria-labelledby="feedback-question-radio-group">
+			<legend id="feedback-question-radio-group">${question.questionText}</legend>
 			<div class="n-feedback__question-radio__container n-feedback__center-block">`
 	]; // fieldsets can't display: flex
 


### PR DESCRIPTION
This is more of a request for comments rather than for approval.

Added role and aria-labelledby properties to fieldset group and matching id to the fieldset ledgend in an attempt to give Dragon voice command something else to work with. However my understanding is these properties are usually used instead of defining fieldset and legend. 
