### PR TITLE
fix o-overlay import compatibility with npm and bower

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
-const Overlay = require('o-overlay').default;
+// o-overlay export is different depending on if n-feedback is being imported using bower or npm
+let Overlay = require('o-overlay');
+Overlay = Overlay.default || Overlay;
+
 const surveyBuilder = require('./src/survey-builder');
 const postResponse = require('./src/post-response');
 const getAdditionalInfo = require('./src/get-additional-info');


### PR DESCRIPTION
In this [other merged PR](https://github.com/Financial-Times/n-feedback/pull/97) we are improving the compatibility of `n-feedback` with npm and bower. Unfortunately when importing `n-feedback` from npm it's crashing when using the o-overlay library with this error:

```
Overlay is not a constructor
```

This happens because [this line](https://github.com/Financial-Times/n-feedback/blob/cb17f6e1f35f6be4bb89169373bf401f9e8832e1/index.js#L1) returns undefined depending on the user of how `n-feedback` is imported (bower / npm)