### PR TITLE
AACERT-164 remove aria-live assertive on the advice of DAC report

### DIFF
--- a/src/survey-builder.js
+++ b/src/survey-builder.js
@@ -130,7 +130,7 @@ function buildSurvey (surveyData, surveyId, domain) {
 	};
 
 	const surveyHTML = [
-		`<div class="n-feedback__survey" aria-live="assertive">
+		`<div class="n-feedback__survey">
 			<a class="n-feedback__survey__close-button o-overlay__close" href="#void">
 				<span>I don't want to give feedback</span>
 			</a>


### PR DESCRIPTION
## Jira ticket
https://financialtimes.atlassian.net/browse/AACERT-164

## From the DAC report:

### Problem

> The `<div>` element containing the feedback pop-up, has been provided with an ‘aria-live’ attribute with a value of ‘assertive’. This means that any changes made within the pop-up are audibly announced as status messages and updates for users of screen reading assistive technologies. Because of the ‘assertive’ value whenever a user enters any text into the input field regarding the reason, the content is all announced after every letter and keypress.

### Solution

> Remove the ‘aria-live’ attribute so that the content does not constantly audibly announce as an update for users of screen reading assistive technologies filling out the feedback form.

### 🤨 
`aria-live="assertive"` has been added in #67 as a fix for `DAC_Status_message_not_announced_Issue4` back in 2019. If you're reading this in the future because the report brought up a "message not announced" issue, well... feel free to push back. 