### PR TITLE
chore: update to node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,69 +3,59 @@
 
 references:
 
-  container_config_node:
-    &container_config_node
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
       - image: cimg/node:<< parameters.node-version >>-browsers
     parameters:
       node-version:
-        default: "16.14"
+        default: "18.17"
         type: string
 
-  container_config_lambda_node:
-    &container_config_lambda_node
+  container_config_lambda_node: &container_config_lambda_node
     working_directory: ~/project/build
     docker:
       - image: lambci/lambda:build-nodejs<< parameters.node-version >>
     parameters:
       node-version:
-        default: "14.19"
+        default: "18.17"
         type: string
 
   workspace_root: &workspace_root ~/project
 
-  attach_workspace:
-    &attach_workspace
+  attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
 
-  npm_cache_keys:
-    &npm_cache_keys
+  npm_cache_keys: &npm_cache_keys
     keys:
       - v1-dependency-npm-{{ checksum "package.json" }}-
       - v1-dependency-npm-{{ checksum "package.json" }}
       - v1-dependency-npm-
 
-  cache_npm_cache:
-    &cache_npm_cache
+  cache_npm_cache: &cache_npm_cache
     save_cache:
       key: v1-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
       paths:
         - ./node_modules/
 
-  restore_npm_cache:
-    &restore_npm_cache
+  restore_npm_cache: &restore_npm_cache
     restore_cache:
       <<: *npm_cache_keys
 
-  filters_only_main:
-    &filters_only_main
+  filters_only_main: &filters_only_main
     branches:
       only: main
 
-  filters_ignore_main:
-    &filters_ignore_main
+  filters_ignore_main: &filters_ignore_main
     branches:
       ignore: main
 
-  filters_ignore_tags:
-    &filters_ignore_tags
+  filters_ignore_tags: &filters_ignore_tags
     tags:
       ignore: /.*/
 
-  filters_version_tag:
-    &filters_version_tag
+  filters_version_tag: &filters_version_tag
     tags:
       only:
         - /^v?\d+\.\d+\.\d+(?:-beta\.\d+)?$/
@@ -86,8 +76,8 @@ jobs:
       - run:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1
-            git@github.com:Financial-Times/next-ci-shared-helpers.git
-            .circleci/shared-helpers
+            git@github.com:Financial-Times/next-ci-shared-helpers.git --branch
+            unpin-heroku .circleci/shared-helpers
       - *restore_npm_cache
       - node/install-npm:
           version: "^7"
@@ -148,14 +138,14 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.20", "18.17" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.20", "18.17" ]
 
   build-test-publish:
     jobs:
@@ -165,7 +155,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.20", "18.17" ]
       - test:
           filters:
             <<: *filters_version_tag
@@ -174,13 +164,13 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.20", "18.17" ]
       - publish:
           context: npm-publish-token
           filters:
             <<: *filters_version_tag
           requires:
-            - test-v16.14
+            - test-v18.17
 
   nightly:
     triggers:
@@ -194,7 +184,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.20", "18.17" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -202,7 +192,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.20", "18.17" ]
 
 notify:
   webhooks:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ demo-build:
 	@cp index.js node_modules/n-feedback/index.js
 	@cp -r src/ node_modules/n-feedback/src/
 	@cp -r templates/ node_modules/n-feedback/templates/
-	@webpack --mode development
+	@NODE_OPTIONS="--openssl-legacy-provider" webpack --mode development
 	@$(DONE)
 
 demo: demo-build

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@financial-times/n-feedback",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@financial-times/dotcom-server-handlebars": "3.0.0",
@@ -38,8 +37,8 @@
         "webpack-cli": "^3.1.2"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "@financial-times/o-buttons": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   "license": "MIT",
   "scripts": {
     "commit": "commit-wizard",
-    "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "devDependencies": {
     "@financial-times/dotcom-build-base": "3.0.0",
@@ -56,11 +55,10 @@
     }
   },
   "volta": {
-    "node": "16.14.0",
-    "npm": "7.20.2"
+    "node": "18.17.1"
   },
   "engines": {
-    "node": "14.x || 16.x",
-    "npm": "7.x || 8.x"
+    "node": "16.x || 18.x",
+    "npm": "7.x || 8.x || 9.x"
   }
 }


### PR DESCRIPTION
You’ll need to upgrade the package to Node, release a new version, and implement that new version in consuming apps, ensuring everything works well in that consuming app
The platforms team have provided a [migration script](https://github.com/Financial-Times/platform-scripts/blob/main/upgrade-node-18/README.md).
[ACC-2437](https://financialtimes.atlassian.net/browse/ACC-2437)