### PR TITLE
remove n-logger use console.error

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const surveyBuilder = require('./src/survey-builder');
 const postResponse = require('./src/post-response');
 const getAdditionalInfo = require('./src/get-additional-info');
 const dictionary = require('./src/dictionary');
-const logger = require('@financial-times/n-logger').default;
 
 
 function getSurveyData(surveyId) {
@@ -180,7 +179,8 @@ module.exports.init = (appInfo = {}) => {
 
 	const container = document.querySelector(`${containerSelector} .n-feedback__container`);
 	if (!container) {
-		logger.error('The container was not found on the page.')
+		// eslint-disable-next-line no-console
+		console.error('The container was not found on the page.')
 		throw new Error('The container was not found on the page.');
 	}
 	container.classList.remove('n-feedback--hidden');


### PR DESCRIPTION
for this conversation on slack:
https://financialtimes.slack.com/archives/C3LRB6JCE/p1694688211442669

we have to remove n-logger and use console.error instead